### PR TITLE
Embed youtube links

### DIFF
--- a/_posts/2019-07-25-pipa_resultado_2019_2.html
+++ b/_posts/2019-07-25-pipa_resultado_2019_2.html
@@ -8,7 +8,11 @@ categories: news
 <center>
 <img src="{{ site.baseurl }}/assets/pipa.jpg" width="500px">
 </center>
+<hr>
 
+<center><h2> Individual </h2></center>
+<p>
+    
 <p> Nesta edição do prêmio, a bolsa individual vai para o aluno <b>Andrew Ijano Lopes</b>. Andrew ingressou no BCC em 2017 e auxiliou na criação do
 Tecs e do IMEsec. É um dos membros ativos do IMESec, participando de
 campeonatos de segurança, organizando eventos e ministrando aulas e
@@ -21,6 +25,9 @@ patrocinada pela <a href="http://www.alura.com.br">Alura</a> e <a
 href="http://www.caelum.com.br">Caelum</a>.
 </p>
 
+<center><h2> Grupo </h2></center>
+<p>
+    
 <p>Pela primeira vez nesta edição do prêmio houve também a inscrição na
 categoria Grupo e este primeiro prêmio vai para alunos do <b>Hardware
 Livre USP</b>. O Hardware Livre USP realiza cursos de Arduino desde 2014

--- a/_posts/2020-01-07-pipa_resultado_2020_1.html
+++ b/_posts/2020-01-07-pipa_resultado_2020_1.html
@@ -8,7 +8,11 @@ categories: news
 <center>
 <img src="{{ site.baseurl }}/assets/pipa.jpg" width="500px">
 </center>
+<hr>
 
+<center><h2> Individual </h2></center>
+<p>
+    
 <p> Nesta edição do prêmio, a bolsa individual vai para o aluno <b>Vitor
 Santa Rosa Gomes</b>. Vitor ingressou no BCC em 2017 e tem sido
 representante de classe (RC) voluntário desde o seu primeiro semestre
@@ -23,6 +27,9 @@ patrocinada pela <a href="http://www.alura.com.br">Alura</a> e <a
 href="http://www.caelum.com.br">Caelum</a>.
 </p>
 
+<center><h2> Grupo </h2></center>
+<p>
+    
 <p>Pela segunda vez na história do prêmio também foram avaliadas
 propostas na categoria Grupo e desta vez o prêmio vai para alunos do <b>Tecs USP</b>. 
 O Tecs é um grupo focado no impacto social da computação e

--- a/_posts/2020-07-20-pipa_resultado_2020_2.html
+++ b/_posts/2020-07-20-pipa_resultado_2020_2.html
@@ -8,7 +8,14 @@ categories: news
 <center>
 <img src="{{ site.baseurl }}/assets/pipa.jpg" width="500px">
 </center>
+<hr>
 
+<center><h2> Individual </h2></center>
+<p>
+<center>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/59Ucc4-56Ew" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</center>
+    
 <p> Nesta edição do prêmio, a bolsa individual vai para o aluno <b>Eduardo Rocha 
 Laurentino </b>. Eduardo ingressou no BCC em 2017, foi representante de classe da sua 
 turma por 4 semestres consecutivos, e no terceiro ano foi eleito pelos colegas 
@@ -28,6 +35,8 @@ patrocinada pela <a href="http://www.alura.com.br">Alura</a> e <a
 href="http://www.caelum.com.br">Caelum</a>.
 </p>
 
+<center><h2> Grupo </h2></center>
+<p>
 <center>
     <iframe width="500" height="315" src="https://www.youtube.com/embed/zszwCKKfj7E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </center>

--- a/_posts/2021-01-29-pipa_resultado_2021_1.html
+++ b/_posts/2021-01-29-pipa_resultado_2021_1.html
@@ -8,7 +8,10 @@ categories: news
 <center>
 <img src="{{ site.baseurl }}/assets/pipa.jpg" width="500px">
 </center>
+<hr>
 
+<center><h2> Individual </h2></center>
+<p>
 <center>
     <iframe width="500" height="315" src="https://www.youtube.com/embed/5qeLLajHww8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </center>
@@ -27,6 +30,8 @@ tecnologia. A bolsa foi patrocinada pela <a href="http://www.alura.com.br">Alura
 href="http://www.caelum.com.br">Caelum</a>.
 </p>
 
+<center><h2> Grupo </h2></center>
+<p>
 <center>
     <iframe width="500" height="315" src="https://www.youtube.com/embed/VZuwjs6gqPE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </center>


### PR DESCRIPTION
Atualiza o design das páginas de resultados do prêmio PIPA que possuem duas categorias e adiciona o embed ao vídeo da entrevista sobre a Liga.