### PR TITLE
Prêmio PIPA 2022/2

### DIFF
--- a/_posts/2022-07-26-pipa_inscricao_2022_2.html
+++ b/_posts/2022-07-26-pipa_inscricao_2022_2.html
@@ -1,0 +1,121 @@
+---
+layout: text
+title: "Inscrições prêmio PIPA 2022/2"
+date: 2022-07-26 00:00
+excerpt: "Estão abertas as inscrições para o prêmio PIPA nas categorias individual
+e em grupo!"
+categories: news
+author: apoio@bcc
+---
+<h4>PIPA: Prêmio de incentivo à participação em atividades </h4>
+
+<p>No Bacharelado em Ciência da Computação temos vários alunos e alunas que desenvolvem, além das atividades didáticas,
+    várias iniciativas extra­curriculares de destaque.</p>
+<p>Alguns exemplos são o <a href="https://uspgamedev.org/" target="_blank">USPGameDev</a> (grupo de desenvolvedores de
+    jogos), <a href="http://hardwarelivreusp.org" target="_blank">HardwareLivre</a> (grupo interessado em plataformas
+    livres de
+    hardware), <a href="https://www.ime.usp.br/~maratona/" target="_blank">MaratonUSP</a> (grupo de alunos interessados
+    em competições de programação), etc.</p>
+<p>Nosso objetivo com este prêmio é valorizar os excelentes alunos e alunas, que tenham um desempenho destacado no curso
+    e, além disso,
+    se envolvam com outras atividades extracurriculares e de formação e desempenhem um papel de liderança contribuindo
+    para o ambiente acadêmico universitário.</p>
+<p>Além disso, esse prêmio também tem o objetivo de incentivar a continuidade das atividades. Desta forma, quem tiver
+    interesse
+    deve submeter um plano de ações para o período do prêmio.</p>
+<p>Esperamos que esse incentivo ajude na formação de lideranças no curso. </p>
+
+<p>Para conhecer algumas das ganhadoras e alguns dos ganhadores das edições
+    passadas do PIPA, assista às entrevistas disponibilizadas
+    <a href="https://www.youtube.com/playlist?list=PLlHCTaNDVU3We8KhVh1BFDkIbyB3tmKB_" target="_blank">aqui</a>
+    no canal do BCC no YouTube.
+</p>
+
+<p>
+    Para o segundo semestre de 2022 estamos oferecendo prêmios em duas
+    categorias: Individual e Grupo.
+</p>
+
+
+<p>
+    Na categoria Individual as bolsas tem o valor de R$ 1000,00 por 6
+    (seis) meses. Uma bolsa é patrocinada pelas empresas
+    <a href="http://www.caelum.com.br"> Caelum</a> e <a href="http://www.alura.com.br"> Alura</a>,
+    fundadas por ex-alunos do BCC. Outras bolsas estão em negociação.
+</p>
+
+
+<p>
+    As inscrições devem ser feitas até 15 de agosto de 2022 preenchendo
+    <a href="https://forms.gle/YavjdtG76rTFMfLQ8"> este formulário</a>. O resultado será
+    divulgado até 29 de agosto de 2022. O início da bolsa será em 1 de setembro de 2022.
+</p>
+
+<p>Vencedores de edições anteriores também podem se inscrever!</p>
+
+<p>
+    O julgamento levará em conta:
+<ul>
+    <li> Histórico escolar do candidato </li>
+    <li> Atividades extra­curriculares desenvolvidas </li>
+    <li> Liderança e envolvimento do aluno com as atividades do BCC </li>
+    <li> Descrição das atividades planejadas para o período do prêmio </li>
+</ul>
+</p>
+
+<p>
+    Na categoria Grupo os prêmios correspondem a 1
+    parcela única no valor de R$ 2.000,00 que venha a auxiliar em alguma atividade de um grupo de
+    alunos(as), já existente ou não, em pesquisa ou extensão. Uma parcela
+    é patrocinada por ex-alunos do BCC. Outras parcelas estão em
+    negociação.
+</p>
+
+<p>
+    As inscrições devem ser feitas até 15 de agosto de 2022
+    preenchendo <a href="https://forms.gle/KoimuRNSQ5epX9r49"> este formulário</a>. O
+    resultado será divulgado até 29 de agosto de 2022. O pagamento da parcela será
+    em setembro de 2022.
+</p>
+
+<p>Vencedores de edições anteriores também podem se inscrever!</p>
+
+<p>
+    O julgamento levará em conta:
+<ul>
+    <li> Histórico escolar dos integrantes do grupo </li>
+    <li> Atividades extra­curriculares desenvolvidas </li>
+    <li> Liderança e envolvimento dos integrantes com as atividades do BCC </li>
+    <li> Descrição das atividades planejadas para o período do prêmio,
+        destacando como o prêmio será aplicado </li>
+</ul>
+</p>
+
+<p>
+    A comissão que selecionará os premiados(as) é composta por professores
+    e alunos do Departamento de Ciência da Computação e por ex-alunos do
+    Bacharelado em Ciência da Computação.
+</p>
+
+<hr>
+<div class="row">
+    <div class="col m6 s12">
+        <center><img src="{{ site.baseurl }}/assets/logobcc.png" height=50></center>
+    </div>
+    <div class="col m6 s12">
+        <center><img src="{{ site.baseurl }}/assets/logoime.png" height=50></center>
+    </div>
+</div>
+<div class="row">
+    <div class="col m6 s12">
+        <a href="https://www.alura.com.br">
+            <center><img src="{{ site.baseurl }}/assets/logoalura.svg" height=50></center>
+        </a>
+    </div>
+    <div class="col m6 s12">
+        <a href="https://www.caelum.com.br">
+            <center><img src="{{ site.baseurl }}/assets/logocaelum.svg" height=50></center>
+        </a>
+    </div>
+</div>
+Imagem obtida com licença creative commons de https://pixabay.com/en/fly-a-kite-child-playing-street-play-1242614/

--- a/catalogo2017/disciplinas/MAC0110.html
+++ b/catalogo2017/disciplinas/MAC0110.html
@@ -23,9 +23,6 @@ Desenvolvimento e documentação de programas.&nbsp;
 Exemplos de processamento não-numérico.&nbsp;
 Extensa prática de programação e depuração de programas.
 
-<p>PRÉ-REQUISITO NÃO-OFICIAL PARA A LM:&nbsp;
-<a href="MAC0118.html">MAC0118</a>.
-
 <P>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
 4 horas, 4 créditos.
 
@@ -77,22 +74,5 @@ LM.   <!-- semestre 4 do currículo (diurno e noturno) -->
 
 <p>&nbsp;
 <p>[Veja dados da disciplina 
-<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0110&verdis=3"
+<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0110"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~yoshi/mac110/"
->1999/1</a>,
-<!--
-<a href="http://www.vision.ime.usp.br/~nina/mac110/notas"
->2001/2</a>
--->
-<a href="http://www.ime.usp.br/~cesar/courses/mac110"
->2001/1</a>,
-<a href="http://www.ime.usp.br/~jstern/introdcomp/"
->2002/1</a>,
-<a href="http://www.ime.usp.br/~kunio/Kunio/www/mac11x/IME2002/info.html"
->2002/2</a>,
-<a href="http://www.ime.usp.br/~egbirgin/courses/2002/mac110/"
->2002/2</a>

--- a/catalogo2017/disciplinas/MAC0121.html
+++ b/catalogo2017/disciplinas/MAC0121.html
@@ -10,7 +10,7 @@ layout: text
 <p>
  <span class="dim">
 Até 2014 se chamou 
-<a href="../../catalogo2014/disciplinas/MAC0122.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0122"
 >MAC0122</a> <i>Princípios de Desenvolvimento de Algoritmos</i></span>.
 </p>
 
@@ -186,19 +186,15 @@ LM, BF (sem 2 do curriculo), LF (sem 2 do curriculo).
 
 <hr>
 <!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:
+Alguns dos oferecimentos da disciplina:
 <a href="http://www.ime.usp.br/~cef/mac122/"
 >1997/2</a>,
 <a href="http://www.ime.usp.br/~yoshi/mac122/"
 >1998/2</a>,
-<a href="http://www.ime.usp.br/~mms/mac1221s1999.html"
->1999/1</a>,
 <a href="http://www.ime.usp.br/~pf/mac0122-1999/"
 >1999/2</a>,
 <a href="http://www.ime.usp.br/~is/ddt/mac122/"
 >1999/2</a>,
-<a href="http://www.ime.usp.br/~cesar/courses/mac122/"
->2000/1</a>,
 <a href="http://www.ime.usp.br/~is/ddt/mac122-00/"
 >2000/2</a>,
 <a href="http://www.ime.usp.br/~cef/mac122-2000/"
@@ -209,8 +205,6 @@ Alguns dos  oferecimentos da disciplina:
 >2001/2</a>,
 <a href="http://www.ime.usp.br/~cris/mac122/"
 >2002/1</a>,
-<a href="http://www.ime.usp.br/~jose/mac122/"
->2002/2</a>,
 <a href="http://www.ime.usp.br/~leliane/MAC122-2002/"
 >2002/2</a>,
 <a href="http://www.ime.usp.br/~pf/mac0122-2002/"

--- a/catalogo2017/disciplinas/MAC0213.html
+++ b/catalogo2017/disciplinas/MAC0213.html
@@ -8,8 +8,7 @@ layout: text
 <!-- versão 1: criada em 2014 para o grade 2015 -->
 
 Está disciplina é inspirada e idêntica a disciplina de 
-mesmo nome oferecida na 
-<a href="http://www.acc.ufba.br/oquee/">Universidade Federal da Bahia</a>.<br>
+mesmo nome oferecida na Universidade Federal da Bahia.<br>
 
 Nesta disciplina teremos apenas um agente além do aluno.
 Um professor supervisor que deverá ser um docente do 
@@ -120,11 +119,7 @@ notas destas atividades e também uma análise do comprometimento
 McGraw-Hill, 1990.
 -->
  	 
-<li>ACC - Atividade Curricular em Comunidade, 
-[Online; acessado em 21-janeiro-2014], URL:
-  <a href="http://www.acc.ufba.br/oquee/"><tt>http://www.acc.ufba.br/oquee/</tt>
-</a>.
-  
+<li>ACC - Atividade Curricular em Comunidade, UFBA. 
 </ul>
 
 <p>OBSERVAÇÃO:&nbsp;

--- a/catalogo2017/disciplinas/MAC0214.html
+++ b/catalogo2017/disciplinas/MAC0214.html
@@ -96,6 +96,7 @@ final do aluno.
 
 
 <p>BIBLIOGRAFIA BÁSICA:&nbsp;
+Não há
 <ul>
 <!--
 <li>T.H. Cormen, C.E. Leiserson, R.L. Rivest, 

--- a/catalogo2017/disciplinas/MAC0215.html
+++ b/catalogo2017/disciplinas/MAC0215.html
@@ -56,6 +56,7 @@ de pesquisa desenvolvida e pela nota final do aluno.
 
 
 <p>BIBLIOGRAFIA BÁSICA:&nbsp;
+Não há
 <ul>
 <!--
 <li>T.H. Cormen, C.E. Leiserson, R.L. Rivest, 

--- a/catalogo2017/disciplinas/MAC0216.html
+++ b/catalogo2017/disciplinas/MAC0216.html
@@ -14,7 +14,7 @@ layout: text
 <p>
 <span class="dim">
 Até 2015 se chamou
-<a href="../../catalogo2015/disciplinas/MAC0211.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0211"
 >MAC0211</a> <i>Laboratório de Programação I</i>.
 </span>
 </p>
@@ -169,16 +169,3 @@ Disciplina obrigatória no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0216"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<!--
-<a href="http://www.ime.usp.br/~kon/MAC211/"
->2002/1</a>,
-<a href="http://www.ime.usp.br/~kon/MAC211-2001"
->2001/1</a>,
-<a href="http://mairinque.ime.usp.br/~gubi/cursos/211/index.html"
->2001/1</a>,
-<a href="http://www.ime.usp.br/~reverbel/mac211-99/"
->1999/1</a>
--->

--- a/catalogo2017/disciplinas/MAC0218.html
+++ b/catalogo2017/disciplinas/MAC0218.html
@@ -107,11 +107,3 @@ Disciplina optativa eletiva nos currículos do
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0218"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos oferecimentos da disciplina:
-<!--
-<a href="http://www.ime.usp.br/~pf/mac0121-2015/"
->2015/2</a>.
--->

--- a/catalogo2017/disciplinas/MAC0219.html
+++ b/catalogo2017/disciplinas/MAC0219.html
@@ -58,7 +58,7 @@ layout: text
     <i>The art of Multiperocessor Programming</i>,
     2008. Morgan Kauffman-Elsevier
   <li> V. Eijkhout, <i>Introduction to High-Performance Scientific Computing</i>,
-    2014, <a = href="http://pages.tacc.utexas.edu/~eijkhout/istc/html/index.html">http://pages.tacc.utexas.edu/~eijkhout/istc/html/index.html</a>
+    2014
   <li> W. Gropp, T. Hoefler, R. Thakur, E. Lusk,
     <i>Using Advanced MPI: Modern Features of the Message-Passing Interface (Scientific and Engineering Computation)</i>,
     2014. MIT Press
@@ -87,11 +87,3 @@ layout: text
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0219"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos oferecimentos da disciplina:
-<!--
-<a href="http://www.ime.usp.br/~pf/mac0121-2015/"
->2015/2</a>.
--->

--- a/catalogo2017/disciplinas/MAC0239.html
+++ b/catalogo2017/disciplinas/MAC0239.html
@@ -10,7 +10,7 @@ layout: text
 <p>
 <span class="dim">
 Até 2014 se chamou
-<a href="../../catalogo2014/disciplinas/MAC0239.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=mac0239&verdis=1"
 >MAC0239</a> <i>Métodos Formais em Programação</i>
 </span>
 </p>
@@ -96,8 +96,3 @@ Disciplina obrigatória no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0239"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~mfinger/2002/mac239"
->2002/2</a>

--- a/catalogo2017/disciplinas/MAC0242.html
+++ b/catalogo2017/disciplinas/MAC0242.html
@@ -73,8 +73,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>&nbsp;
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0242">no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://mairinque.ime.usp.br/~gubi/cursos/242/index.html"
->2002/2</a>

--- a/catalogo2017/disciplinas/MAC0315.html
+++ b/catalogo2017/disciplinas/MAC0315.html
@@ -12,7 +12,7 @@ layout: text
 <p>
  <span class="dim">
 Até 2016 se chamou 
-<a href="../../catalogo2016/disciplinas/MAC0315.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=mac0315&verdis=2"
 >MAC0315</a> <i>Programação Linear</i></span>.
 </p>
 
@@ -113,17 +113,7 @@ para o <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC03
 
 <hr>
 Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~leo/mac315/02-2/html"
->2002/2</a>,
-<a href="http://www.ime.usp.br/~egbirgin/courses/old/2002/mac315/"
->2002/1</a>
 <a href="http://www.ime.usp.br/~egbirgin/courses/2002/mac315/index.html"
 >2002/1</a>,
-<a href="http://www.ime.usp.br/~leo/mac315/01-2/html"
->2001/2</a>,
-<a href="http://www.ime.usp.br/~leo/mac315/00-2/html"
->2000/2</a>,
-<a href="http://www.ime.usp.br/~leo/mac315/00/html"
->2000/1</a>,
 <a href="http://www.ime.usp.br/~coelho/mac315/"
 >1999/1</a>.

--- a/catalogo2017/disciplinas/MAC0317.html
+++ b/catalogo2017/disciplinas/MAC0317.html
@@ -11,7 +11,7 @@ layout: text
 <p>
 <span class="dim">
 Até 2016 se chamou
-<a href="../../catalogo2016/disciplinas/MAC0317.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=mac0317&verdis=1"
    >MAC0317</a> <i>Algoritmos para Processamento de Áudio, Imagem e Vídeo</i>.
 </span>
 </p>
@@ -118,5 +118,5 @@ Disciplina optativa eletiva no currículo do BCC.
 
 <p>&nbsp;
 <p>[Veja dados da disciplina 
-<a href="https://sistemas.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0317"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=mac0317"
 >no JúpiterWeb</a>]

--- a/catalogo2017/disciplinas/MAC0320.html
+++ b/catalogo2017/disciplinas/MAC0320.html
@@ -10,7 +10,7 @@ A teoria dos grafos é usada
 na modelagem de muitos problemas computacionais.
 Esta disciplina tem o objetivo de introduzir o aluno
 à linguagem e aos problemas básicos da teoria.
-A disciplina complementa MAC0328 Algoritmos em Grafos,
+A disciplina complementa <a href="MAC0328.html">MAC0328 Algoritmos em Grafos</a>,
 que trata dos aspectos mais algorítmicos da teoria.
 
 

--- a/catalogo2017/disciplinas/MAC0323.html
+++ b/catalogo2017/disciplinas/MAC0323.html
@@ -153,8 +153,6 @@ Alguns oferecimentos da disciplina:
 >1999/1</a>,
 <a href="http://www.ime.usp.br/~yoshi/2001i/mac323/"
 >2001/1</a>,
-<a href="http://www.ime.usp.br/~song/mac323.html"
->2002/1</a>,
 <a href="http://www.ime.usp.br/~yoshi/2008i/mac323/"
    >2008/1</a>,
 <a href="http://www.ime.usp.br/~yoshi/2012i/mac323/"

--- a/catalogo2017/disciplinas/MAC0325.html
+++ b/catalogo2017/disciplinas/MAC0325.html
@@ -86,6 +86,4 @@ Oferecimentos recentes da disciplina:
 <a href="http://www.ime.usp.br/~cef/mac325/"
 >1998/2</a>,
 <a href="http://www.ime.usp.br/~coelho/mac325/"
->2000/2</a>,
-<a href="http://www.ime.usp.br/~pf/mac0325-2002/"
->2002/1</a>.
+>2000/2</a>.

--- a/catalogo2017/disciplinas/MAC0326.html
+++ b/catalogo2017/disciplinas/MAC0326.html
@@ -128,6 +128,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0440&codcur=45051&codhab=1"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:

--- a/catalogo2017/disciplinas/MAC0327.html
+++ b/catalogo2017/disciplinas/MAC0327.html
@@ -11,7 +11,7 @@ layout: text
 Criar condições para que o aluno de computação
 desenvolva suas habilidades de resolução de problemas computacionais.
 O ambiente é semelhante aos concursos de programação
-<a href="http://acm.baylor.edu/icpc"
+<a href="https://icpc.global"
 ><acronym title="Association for Computing Machinery"
 >ACM</acronym>
 <i>International Collegiate Programming Contest</i></a>
@@ -32,23 +32,20 @@ A disciplina tem caráter de laboratório,
 com intensa atividade de programação.
 <!--com 1 ou 2 problemas de programação por aula.-->
 Todos os programas 
-criados pelos alunos são submetidos aos "juízes eletrônicos" 
-do <i>Programming Challenges</i>
-(http://www.programming-challenges.com)
-e do
-<i>Valladolid Programming Contest Site</i>
-(http://acm.uva.es).&nbsp;
+criados pelos alunos são submetidos aos "juízes eletrônicos".
 Os problemas de programação cobrem os seguintes tópicos:
-estruturas de dados,
-ordenação,
-aritmética, 
-álgebra,
-combinatória,
-teoria dos números,
-<i>backtracking</i>,
-grafos,
-programação dinâmica,
-geometria.
+
+1. problemas matemáticos envolvendo conceitos de teoria dos números e/ou combinatória; 
+2. problemas com vetores, matrizes e strings; 
+3. recorrências e recursão; 
+4. problemas envolvendo ordenação e busca; 
+5. problemas com filas e pilhas; 
+6. problemas com grafos e árvores; 
+7. busca em largura e busca em profundidade; 
+8. estratégia gulosa; 
+9. programação dinâmica e 
+10. backtracking.
+
 
 <p>PRÉ-REQUISITOS:&nbsp;
 <a 
@@ -74,24 +71,18 @@ Média ponderada de provas e exercícios.
 
 <p>BIBLIOGRAFIA BÁSICA:&nbsp;
 <ul>
+
 <li>
-<a href="http://www.cs.sunysb.edu/~skiena"
->S.<!--Steven--> S. Skiena</a>,
-<a href="http://www.mac.cie.uva.es/~revilla/"
->M.<!--Miguel--> A. Revilla</a>,&nbsp;
+  S.<!--Steven--> S. Skiena,
+  M.<!--Miguel--> A. Revilla,
 <i>Programming Challenges: 
 The Programming Contest Training Manual</i>,&nbsp;
 Springer, 2003.
-
+</li>
 <li>
-<i>Programming Challenges</i>,&nbsp;
-&laquo;<a href="http://www.programming-challenges.com"
->http://www.programming-challenges.com</a>&raquo;
-
-<li>
-<i>Valladolid Programming Contest Site</i>,&nbsp;
-&laquo;<a href="http://acm.uva.es"
->http://acm.uva.es</a>&raquo;
+  T.H. Cormen, C.E. Leiserson, R.L. Rivest, C. Stein,
+  <i>Introduction to Algorithms (3rd ed.)</i>, MIT Press and McGraw-Hill, 2009.
+</li>
 
 </ul> 
 
@@ -108,8 +99,6 @@ Disciplina optativa eletiva no currículo do BCC.
 
 <p>&nbsp; 
 <p>[Veja dados da disciplina 
-<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0xxxxxx&amp;codcur=45051&amp;codhab=1">no JúpiterWeb</a>]
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=mac0327">no JúpiterWeb</a>]
 
-</p><hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~cris/desafios.html">2004</a>.
+</p>

--- a/catalogo2017/disciplinas/MAC0328.html
+++ b/catalogo2017/disciplinas/MAC0328.html
@@ -99,8 +99,6 @@ Disciplina optativa eletiva no currículo do BCC.
 
 <hr>
 Oferecimentos da disciplina:
-<a href="http://www.ime.usp.br/~jose/grafos/"
->1998/2</a>,
 <a href="http://www.ime.usp.br/~coelho/mac328/"
 >1999/2</a>,
 <a href="http://www.ime.usp.br/~pf/mac0328-2000/"

--- a/catalogo2017/disciplinas/MAC0329.html
+++ b/catalogo2017/disciplinas/MAC0329.html
@@ -12,10 +12,10 @@ layout: text
 <p>
 <span class="dim">
 Até 2015 se chamou
-<a href="../../catalogo2015/disciplinas/MAC0329.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0329&verdis=1"
    >MAC0329</a> <i>Álgebra Booleana e Aplicações.</i><br>
 Em 2016 se chamou
-<a href="../../catalogo2016/disciplinas/MAC0329.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0329&verdis=2"
    >MAC0329</a> <i>Álgebra Booleana e Circuitos Digitais</i>.
 </span>
 </p>

--- a/catalogo2017/disciplinas/MAC0331.html
+++ b/catalogo2017/disciplinas/MAC0331.html
@@ -160,14 +160,6 @@ Disciplina optativa eletiva no currículo do BCC.
 
 <hr>
 Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~cris/14_2_331/"
->2014/2</a>,
-<a href="http://www.ime.usp.br/~cris/11_2_331/"
->2011/2</a>,
-<a href="http://www.ime.usp.br/~cris/09_2_331/"
->2009/2</a>,
-<a href="http://www.ime.usp.br/~cris/07_2_331/"
->2007/2</a>,
 <a href="http://www.ime.usp.br/~walterfm/cursos/mac0331/2006/gc2006.htm"
 >2006/1</a>,
 <a href="http://www.ime.usp.br/~walterfm/cursos/mac0331/2004/mac0331_04.html"

--- a/catalogo2017/disciplinas/MAC0336.html
+++ b/catalogo2017/disciplinas/MAC0336.html
@@ -79,8 +79,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0336&codcur=45051&codhab=1"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~rt/mac5723/"
->2002/1</a>.

--- a/catalogo2017/disciplinas/MAC0338.html
+++ b/catalogo2017/disciplinas/MAC0338.html
@@ -212,13 +212,11 @@ Disciplina obrigatória no currículo do BCC.
 
 <hr>
 Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~pf/mac338-1999/"
->1999</a>,
 <a href="http://www.ime.usp.br/~yoshi/mac338/"
 >2000/1</a>,
 <a href="http://www.ime.usp.br/~cris/mac338/"
 >2001/1</a>,
 <a href="http://www.ime.usp.br/~pf/mac0338-2002/"
->2002/1</a>.
+>2002/1</a>,
 <a href="http://www.ime.usp.br/~pf/mac0338-2010/"
 >2010/1</a>

--- a/catalogo2017/disciplinas/MAC0341.html
+++ b/catalogo2017/disciplinas/MAC0341.html
@@ -120,9 +120,5 @@ Disciplina optativa nos currículos do BCC.
 
 <p>&nbsp;
 <p>[Veja dados da disciplina 
-<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0???"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0341"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0343.html
+++ b/catalogo2017/disciplinas/MAC0343.html
@@ -11,7 +11,7 @@ layout: text
 <p>
  <span class="dim">
 Até 2016 se chamou 
-<a href="../../catalogo2016/disciplinas/MAC0343.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0343&verdis=1"
 >MAC0343</a> <i>Programação Semidefinida e Aplicações</i></span>.
 </p>
 
@@ -129,7 +129,3 @@ LM, BF (sem 2 do curriculo), LF (sem 2 do curriculo).
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0343"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0344.html
+++ b/catalogo2017/disciplinas/MAC0344.html
@@ -88,11 +88,3 @@ LM, BF (sem 2 do curriculo), LF (sem 2 do curriculo).
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0344"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos oferecimentos da disciplina:
-<!--
-<a href="http://www.ime.usp.br/~pf/mac0121-2015/"
->2015/2</a>.
--->

--- a/catalogo2017/disciplinas/MAC0345.html
+++ b/catalogo2017/disciplinas/MAC0345.html
@@ -1,0 +1,84 @@
+---
+title: 'MAC0345&nbsp; Desafios de Programação Avançados'
+layout: text
+---
+<!--2016-->
+<!-- 24/05/2016 -->
+
+<!-- versão 1 (2016) -->
+
+
+<p>OBJETIVOS:&nbsp;
+
+Aprimorar habilidades de resolução de problemas computacionais em um ambiente semelhante ao de concursos internacionais de programação como o ICPC e à Maratona de Programação da SBC. Os problemas de programação propostos levam ao aprofundamento do aprendizado de técnicas de desenvolvimento e análise de algoritmos, incluindo o uso de estruturas de dados sofisticadas e uma ampla variedade de estratégias de resolução de problemas computacionais.
+
+<p>PROGRAMA RESUMIDO:&nbsp;
+
+Os problemas de programação envolvem diversos tópicos de Ciência da Computação, tais como estruturas de dados, ordenação, combinatória e matemática (contagem, álgebra, etc), backtracking, grafos e geometria computacional. Espera-se que o aluno tenha bons conhecimentos de tópicos clássicos de análise de algoritmos e estruturas de dados.
+
+<p>PROGRAMA:&nbsp;
+1. problemas matemáticos envolvendo conceitos de teoria dos números e/ou combinatória;
+2. recorrências e recursão;
+3. problemas envolvendo ordenação e busca;
+4. problemas com estruturas de dados diversas;
+5. problemas com grafos e árvores;
+6. estratégia gulosa;
+7. programação dinâmica;
+8. backtracking;
+9. simulação;
+10. problemas de geometria computacional.
+
+<p>RESPONSÁVEIS:&nbsp;
+Cristina Gomes Fernandes
+Marcel Kenji de Carli Silva
+
+<p>PRÉ-REQUISITOS:&nbsp;
+<a href="MAC0121.html">MAC0121</a>.
+
+<p>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
+6 horas, 4 créditos-aula e 2 créditos-trabalho.
+
+<p>CRITÉRIO DE AVALIAÇÃO DA APRENDIZAGEM:&nbsp;<br>
+  
+A disciplina tem intensa atividade de programação. Todos os programas criados pelos alunos são submetidos a "juízes eletrônicos". A média final é calculada a partir da porcentagem dos programas que foram aceitos pelos juízes eletrônicos dentro dos prazos estabelecidos. A média geral deve ser maior ou igual a 5 para aprovação.<br>
+
+<p>NORMA DE RECUPERAÇÃO:<br>
+Nesta disciplina não há recuperação.
+
+<p>BIBLIOGRAFIA BÁSICA:&nbsp;
+<ul>
+  <li> S. S. Skiena, M. A. Revilla, <i>Programming Challenges: The Programming Contest Training Manual</i>, Springer, 2003
+  <li> T.H. Cormen, C.E. Leiserson, R.L. Rivest, C. Stein, <i>Introduction to Algorithms (3rd ed.)</i>, MIT Press and McGraw-Hill, 2009.
+</ul>
+
+
+
+<p>OBSERVAÇÃO:&nbsp;
+  Disciplina optativa eletiva nos currículos do BCC.
+  <!-- semestre 2 do currículo -->
+  <!-- BMA,   semestre 2 do currículo -->
+  <!-- BMAC,  semestre 2 do currículo --> 
+  <!-- BE     semestre 2 do currículo -->
+  <!--BM.    semestre 2 do currículo --> 
+
+  <!-- 
+       Disciplina optativa eletiva no currículo da 
+       LM, BF (sem 2 do curriculo), LF (sem 2 do curriculo). 
+    -->
+
+
+</blockquote>
+
+
+<p>&nbsp;
+<p>[Veja dados da disciplina 
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0345"
+>no JúpiterWeb</a>]
+
+<hr>
+<!--Oferecimentos recentes da disciplina:-->
+Alguns dos oferecimentos da disciplina:
+<!--
+<a href="http://www.ime.usp.br/~pf/mac0121-2015/"
+>2015/2</a>.
+-->

--- a/catalogo2017/disciplinas/MAC0346.html
+++ b/catalogo2017/disciplinas/MAC0346.html
@@ -88,7 +88,3 @@ BCC.
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0346"
 >no JúpiterWeb</a>]
-
-<hr>
-
-Alguns dos oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0350.html
+++ b/catalogo2017/disciplinas/MAC0350.html
@@ -10,6 +10,7 @@ layout: text
 <span class="dim">
 Esta disciplina foi inspirada nas disciplinas:
 <ul>
+<li> <a>6.005 Elements of Software Construction do MIT</a></li>
 <li> <a href="http://ocw.mit.edu/courses/civil-and-environmental-engineering/1-124j-foundations-of-software-engineering-fall-2000/">1.124J Foundations of Software Engineering do MIT</a>; e
 <li> <a href="http://www.cs.cmu.edu/~charlie/courses/15-214/2015-spring/">15-214 Principles of Software Construction: Objects, Design, and
 Concurrency da CMU</a>.

--- a/catalogo2017/disciplinas/MAC0350.html
+++ b/catalogo2017/disciplinas/MAC0350.html
@@ -10,7 +10,6 @@ layout: text
 <span class="dim">
 Esta disciplina foi inspirada nas disciplinas:
 <ul>
-<li> <a href="http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-005-elements-of-software-construction-fall-2011/">6.005 Elements of Software Construction do MIT</a>;
 <li> <a href="http://ocw.mit.edu/courses/civil-and-environmental-engineering/1-124j-foundations-of-software-engineering-fall-2000/">1.124J Foundations of Software Engineering do MIT</a>; e
 <li> <a href="http://www.cs.cmu.edu/~charlie/courses/15-214/2015-spring/">15-214 Principles of Software Construction: Objects, Design, and
 Concurrency da CMU</a>.

--- a/catalogo2017/disciplinas/MAC0351.html
+++ b/catalogo2017/disciplinas/MAC0351.html
@@ -105,7 +105,3 @@ Disciplina optativa nos currículos do BCC.
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0351"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0352.html
+++ b/catalogo2017/disciplinas/MAC0352.html
@@ -87,11 +87,3 @@ importantes para o desenvolvedor de software.
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0352"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos oferecimentos da disciplina:
-<!--
-<a href="http://www.ime.usp.br/~pf/mac0121-2015/"
->2015/2</a>.
--->

--- a/catalogo2017/disciplinas/MAC0375.html
+++ b/catalogo2017/disciplinas/MAC0375.html
@@ -119,7 +119,3 @@ Disciplina optativa nos currículos do BCC.
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0375"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0385.html
+++ b/catalogo2017/disciplinas/MAC0385.html
@@ -105,7 +105,3 @@ Disciplina optativa nos currículos do BCC.
 <p>[Veja dados da disciplina 
 <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0385"
 >no JúpiterWeb</a>]
-
-<hr>
-<!--Oferecimentos recentes da disciplina:-->
-Alguns dos  oferecimentos da disciplina:

--- a/catalogo2017/disciplinas/MAC0412.html
+++ b/catalogo2017/disciplinas/MAC0412.html
@@ -65,6 +65,4 @@ Oferecimentos recentes da disciplina:
 <a href="http://www.ime.usp.br/~song/mac412-00.html"
 >2000/2</a>,
 <a href="http://www.ime.usp.br/~song/mac412-01.html"
->2001/2</a>,
-<a href="http://www.ime.usp.br/~song/mac412.html"
->2002/2</a>.
+>2001/2</a>.

--- a/catalogo2017/disciplinas/MAC0413.html
+++ b/catalogo2017/disciplinas/MAC0413.html
@@ -15,7 +15,7 @@ layout: text
 <p>
  <span class="dim">
 Até 2016 se chamou 
-<a href="../../catalogo2016/disciplinas/MAC0315.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0413&verdis=1"
 >MAC0413</a> <i>Tópicos de Programação Orientada a Objetos</i></span>.
 </p>
   
@@ -109,8 +109,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0413&codcur=45051&codhab=1"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<!-- <a href="http://www.ime.usp.br/~kon/MAC5715"
->2002/2</a>. -->

--- a/catalogo2017/disciplinas/MAC0414.html
+++ b/catalogo2017/disciplinas/MAC0414.html
@@ -10,16 +10,16 @@ layout: text
 
 <span class="dim">
   <span class="dim">Até 2014 se chamou
-  <a href="../../catalogo2014/disciplinas/MAC0414.html"
+  <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0414&verdis=2"
     >MAC0414</a> <i>Linguagens Formais e Autômatos</i></span>. <br>
 Este disciplina é formada por uma coletânea de tópicos que eram
 apresentados nas extintas
 <blockquote>
-    <a href="../catalogo2014/disciplinas/MAC0414.html"
+    <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0414&verdis=2"
     >MAC0414</a> Linguagens Formais e Autômatos, <br>
-    <a href="../catalogo2014/disciplinas/MAC0423.html"
+    <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0423"
     >MAC0423</a> Introdução à Teoria da Computabilidade, e <br>
-    <a href="../catalogo2014/disciplinas/MAC0430.html"
+    <a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0430"
     >MAC0430</a> Algoritmos e Complexidade de Computação.
 </blockquote>
 </span>

--- a/catalogo2017/disciplinas/MAC0417.html
+++ b/catalogo2017/disciplinas/MAC0417.html
@@ -107,10 +107,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0417&codcur=45051&codhab=1"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~cesar/courses/mac417/"
->2000/1</a>,
-<a href="http://www.vision.ime.usp.br/~nina/vision/index.html"
->2002/1</a>

--- a/catalogo2017/disciplinas/MAC0419.html
+++ b/catalogo2017/disciplinas/MAC0419.html
@@ -102,8 +102,3 @@ Disciplina optativa eletiva no currículo do BCC.
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0419&codcur=45051&codhab=1"
 >no JúpiterWeb</a>]
-
-<hr>
-Oferecimentos recentes da disciplina:
-<a href="http://www.ime.usp.br/~jstern/mac796/index.htm"
->2001/1</a>

--- a/catalogo2017/disciplinas/MAC0422.html
+++ b/catalogo2017/disciplinas/MAC0422.html
@@ -84,6 +84,4 @@ Disciplina obrigatória no currículo do BCC.
 <hr>
 Oferecimentos recentes da disciplina:
 <a href="http://www.ime.usp.br/~dilma/Cursos/98/mac422/"
->1998/2</a>,
-<a href="http://www.ime.usp.br/~durham/cursos/mac422/"
->2002</a>.
+>1998/2</a>.

--- a/catalogo2017/disciplinas/MAC0425.html
+++ b/catalogo2017/disciplinas/MAC0425.html
@@ -81,6 +81,4 @@ Disciplina optativa eletiva no currículo do BCC.
 <hr>
 Oferecimentos recentes da disciplina:
 <a href="http://www.ime.usp.br/~renata/mac425/"
->2002/2</a>,
-<a href="http://www.ime.usp.br/~leliane/IAcurso2001"
->2001/2</a>.
+>2002/2</a>.

--- a/catalogo2017/disciplinas/MAC0427.html
+++ b/catalogo2017/disciplinas/MAC0427.html
@@ -11,7 +11,7 @@ layout: text
 <p>
  <span class="dim">
 Até 2016 se chamou 
-<a href="../../catalogo2015/disciplinas/MAC0315.html"
+<a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0427&verdis=2"
 >MAC0427</a> <i>Programação não-Linear</i></span>.
 </p>
 

--- a/catalogo2017/disciplinas/MAC0485.html
+++ b/catalogo2017/disciplinas/MAC0485.html
@@ -1,0 +1,66 @@
+---
+title: 'MAC0485&nbsp; Implicações Sociais da Computação'
+layout: text
+---
+<!--2015-->
+
+<!-- versão 1 -->
+
+<p>OBJETIVOS:&nbsp;
+Apresentar questões sociais, profissionais, legais, éticas, ambientais políticas e humanísticas relacionadas à ciência da computação; Possibilitar a compreensão do impacto da computação e suas tecnologias na sociedade no que concerne ao atendimento e à antecipação estratégica das necessidades da sociedade.
+
+
+<p>PROGRAMA RESUMIDO:&nbsp;
+Introdução à ética e aos impactos sociais em computação.
+Coleta de dados e privacidade.
+Viés algorítmico.
+Autoria e propriedade intelectual.
+Ética profissional.
+
+<p>PROGRAMA:&nbsp;
+[1] Introdução à ética e aos impactos sociais em computação: Ética. Filosofia e ética da tecnologia. O papel do programador e o papel do computador.
+[2] Coleta de dados e privacidade: O que é privacidade? Privacidade de dados e big data.
+[3] Viés algorítmico: Mathwashing. Estudos de caso. Loops de feedback. Justiça, accountability e transparência - o direito à explicação.
+[4] Tecnologia e política: Democracia, liberdade e tecnologia. Capitalismo de vigilância. Tecnologia como vetor p
+[5] Autoria e propriedade intelectual: Propriedade intelectual. Software livre e código aberto. Copyright e copyleft.
+[6] Ética profissional: Diversidade e representatividade. Códigos de conduta.
+
+<p>RESPONSÁVEIS:&nbsp;
+Carlos Eduardo Ferreira
+
+<p>PRÉ-REQUISITOS:&nbsp;
+Essa disciplina não tem requisitos.
+
+<p>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
+4 horas, 2 créditos-aula e 2 créditos-trabalho.
+
+<p>CRITÉRIO DE AVALIAÇÃO DA APRENDIZAGEM:&nbsp; 
+A disciplina será ministrada com aulas expositivas e aulas de discussão. Será exigida a leitura de uma quantidade razoável de textos, quase todos em inglês. O entendimento crítico deste material será avaliado por participação em classe e uma monografia final. Os alunos serão avaliados mediante um trabalho final de aproveitamento, que consistirá em uma monografia crítica sobre um dos temas apresentados durante o semestre. Para a recuperação, o aluno inicialmente avaliado com uma nota no intervalo entre 3.0 e 4.9 terá a oportunidade de reescrever o trabalho final após sua correção comentada. A nota será obtida a partir de uma média ponderada entre a versão inicial e a reescrita.
+
+<p>BIBLIOGRAFIA BÁSICA:&nbsp;
+<ul>
+
+<li>Association of Computing Machinery (2018),
+<i>Code of Ethics and Professional Conduct.</i>
+
+<li>
+	Estados Unidos (2016),
+	<i>Big Data: a report on algorithmic systems, opportunity and civil rights.</i>
+</li>
+
+<li>
+	Turing, Alan M. (1950),
+	<i>Computing Machinery and Intelligence</i>,
+	Mind Vol. 49. pp. 433-460.
+</li>
+
+</ul> 
+
+
+</blockquote>
+
+
+<p>&nbsp;
+<p>[Veja dados da disciplina 
+<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0485"
+>no JúpiterWeb</a>]

--- a/catalogo2017/disciplinas/MAC0499.html
+++ b/catalogo2017/disciplinas/MAC0499.html
@@ -50,9 +50,6 @@ Disciplina obrigatória no currículo do BCC.
 </blockquote>
 <p>&nbsp;
 
-<p><a href="499/mac499.html"
->Mais informações</a>.
-
 <p>[Veja dados da disciplina 
 <a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0499&codcur=45052"
 >no JúpiterWeb</a>]

--- a/catalogo2017/disciplinas/MAC0536.html
+++ b/catalogo2017/disciplinas/MAC0536.html
@@ -1,0 +1,87 @@
+---
+title: 'MAC0536&nbsp; Tópicos de Matemática Discreta II'
+layout: text
+---
+<!--2015-->
+
+<!-- versão 1 -->
+
+<p>OBJETIVOS:&nbsp;
+Expor o aluno com inclinação à matemática e a aspectos teóricos da ciência da computação a tópicos avançados da matemática discreta.
+
+<p>PROGRAMA RESUMIDO:&nbsp;
+Tópicos avançados da matemática discreta.
+
+<p>PROGRAMA:&nbsp;
+Aplicações de funções geradoras, incluindo aplicações a problemas de enumeração.
+Tópicos da teoria dos números.
+Aspectos combinatórios da geometria e, em particular, politopos e cones.
+
+<p>RESPONSÁVEIS:&nbsp;
+Sinai Robins
+
+<p>PRÉ-REQUISITOS:&nbsp;
+<a href="MAC0436.html">MAC0436</a>
+
+<p>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
+3 horas, 4 créditos-aula e 0 créditos-trabalho.
+
+<p>CRITÉRIO DE AVALIAÇÃO DA APRENDIZAGEM:&nbsp; 
+A avaliação é feita por provas e listas de exercícios. O critério de aprovação é dado pela média ponderada das notas de provas e listas de exercícios. Essa disciplina não possui norma de recuperação. A avaliação será baseada em um volume substancial de exercícios ao longo do semestre, que terão o papel de levar ao amadurecimento do aluno na área da disciplina. Não é possível reproduzir algo parecido no processo de recuperação, que tem de ter lugar em um período muito curto.
+
+<p>BIBLIOGRAFIA:&nbsp;
+<ul>
+
+<li>
+	L. Babai e P. Frankl,
+	<i>Linear algebra methods in combinatorics</i>,
+	Department of Computer Science, University of Chicago, preliminary version, 1992.
+</li>
+
+
+<li>
+	M. Beck and S. Robins,
+	<i>Computing the continuous discretely: integer point enumeration in polytopes</i>,
+	2nd edition, 2015.
+</li>
+
+<li>
+	R.L. Graham, D.E. Knuth e O. Patashnik,
+	<i>Concrete Mathematics</i>,
+	Addison-Wesley, 1989.
+</li>
+
+<li>
+	C. Godsil e G. Royle,
+	<i>Algebraic graph theory</i>,
+	Graduate Texts in Mathematics, 207. Springer-Verlag, New York, 2001.
+</li>
+
+<li>
+	N. Linial,
+	<i>Harmonic analysis and combinatorial applications,</i>
+	notas de aula. Disponível em http://www.cs.huji.ac.il/~nati/.
+</li>
+
+<li>
+	T. Tao e V. Vu,
+	<i>Additive combinatorics, Cambridge Studies in Advanced Mathematics, 105.</i>
+	Cambridge University Press, Cambridge, 2006.
+</li>
+
+<li>
+	G.M. Ziegler,
+	<i>Lectures on polytopes</i>,
+	Graduate Texts in Mathematics, Springer-Verlag, 1995.
+</li>
+
+</ul> 
+
+
+</blockquote>
+
+
+<p>&nbsp;
+<p>[Veja dados da disciplina 
+<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0536"
+>no JúpiterWeb</a>]

--- a/catalogo2017/disciplinas/MAC0546.html
+++ b/catalogo2017/disciplinas/MAC0546.html
@@ -1,0 +1,105 @@
+---
+title: 'MAC0546&nbsp; Fundamentos da Internet das Coisas'
+layout: text
+---
+<!--2015-->
+
+<!-- versão 1 -->
+
+<p>OBJETIVOS:&nbsp;
+Apresentar os principais conceitos relacionados ao desenvolvimento de aplicações voltadas para a área de Internet das Coisas (IoT), partindo das tecnologias e arquiteturas disponíveis com o intuito de implementar protótipos funcionais. Os estudantes irão explorar diversas tecnologias de IoT, desenvolver conhecimentos sobre a experiência do usuário com tais tecnologias e realizar tratamento de dados. Outro objetivo vem a ser o de habilitar os estudantes para trabalharem com microcontroladores, microcomputadores, diversos sensores e dispositivos atuadores, interfaces para comunicação sem fio, entre outras tecnologias que permitam a transmissão de dados pela Internet.
+
+<p>PROGRAMA RESUMIDO:&nbsp;
+Introdução à Internet das Coisas e seu panorama atual;
+Obtenção de dados em IoT;
+Conectando coisas;
+Protocolos de rede e Internet para aplicações em IoT;
+Tratamento de dados de sensores;
+Segurança e privacidade em nível de IoT;
+Desenvolvimento de aplicações para cidades inteligentes.
+
+<p>PROGRAMA:&nbsp;
+Introdução à Internet das Coisas e seu panorama atual: Uma visão da área do ponto de vista acadêmico e empresarial;
+Obtenção de dados em IoT: Sensores (temperatura, luminosidade, presença), APIs e dados abertos;
+Conectando coisas: Microcontroladores (Arduino), Microprocessadores (Raspberry Pi), Web Services, Cloud Services;
+Protocolos de rede e Internet para aplicações em IoT: Bluetooth, WiFi, MQTT, CoAP;
+Tratamento de dados de sensores: Filtros, fusão de sensores, e aprendizado de máquina;
+Segurança e privacidade em nível de IoT;
+Desenvolvimento de aplicações para cidades inteligentes.
+
+<p>RESPONSÁVEIS:&nbsp;
+Alfredo Goldman Vel Lejbman
+Daniel Macedo Batista
+Fabio Kon
+
+<p>PRÉ-REQUISITOS:&nbsp;
+<a href="MAC0216.html">MAC0216</a>.
+
+<p>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
+3 horas, 4 créditos-aula e 0 créditos-trabalho.
+
+<p>CRITÉRIO DE AVALIAÇÃO DA APRENDIZAGEM:&nbsp; 
+A avaliação é dada por seminários e por um projeto prático final. O critério de avaliação é calculado pela média ponderada entre trabalhos. A norma de recuperação é dada por um trabalho extra para os alunos.
+
+<p>BIBLIOGRAFIA BÁSICA:&nbsp;
+<ul>
+
+<li>
+	Friess, Peter,
+	<i>Internet of Things-Global Technological and Societal Trends From Smart Environments and Spaces to Green ICT</i>,
+	River Publishers, 2011.
+</li>
+
+<li>
+	Keary, Mae,
+	<i>The Internet of Things (The MIT Press Essential Knowledge Series)</i>,
+	Online Information Review (2016).
+</li>
+
+<li>
+	Kellmereit, Daniel; Daniel Obodovski,
+	<i>The silent intelligence: the internet of things</i>,
+	DnD Ventures, 2013.
+</li>
+
+<li>
+	McRoberts, Michael,
+	<i>Beginning Arduino</i>,
+	New York.: Apress, 2010
+</li>
+
+<li>
+	Javed, Adeel (Autor); Adas, Cláudio José (Tradutor),
+	<i>Criando Projetos com Arduino Para a Internet das Coisas.</i>,
+	Novatec. 2017.
+</li>
+
+<li>
+	Oliveira, Sergio,
+	<i>Internet das Coisas com ESP8266, Arduino e Raspberry Pi</i>,
+	São Paulo: Novatec, 2017.
+</li>
+
+<li>
+	Atzori, L., Iera, A., e Morabito, G. (2010),
+	<i>The Internet of Things: A survey</i>,
+	Computer Networks, 54(15), 2787–2805.
+</li>
+
+<li>
+	Voas, Jeffrey,
+	<i>Networks of ‘things’</i>,
+	NIST Special Publication 800 (2016).
+</li>
+
+
+</ul> 
+
+
+</blockquote>
+
+
+<p>&nbsp;
+<p>[Veja dados da disciplina 
+<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0546"
+>no JúpiterWeb</a>]

--- a/catalogo2017/disciplinas/MAC0552.html
+++ b/catalogo2017/disciplinas/MAC0552.html
@@ -1,0 +1,87 @@
+---
+title: 'MAC0552&nbsp; Tópicos de Otimização Combinatória II'
+layout: text
+---
+<!--2015-->
+
+<!-- versão 1 -->
+
+<p>OBJETIVOS:&nbsp;
+Familiarizar os alunos com assuntos recentes e novas técnicas em otimização combinatória.
+
+<p>PROGRAMA RESUMIDO:&nbsp;
+Tópicos atuais de otimização combinatória.
+
+<p>PROGRAMA:&nbsp;
+Otimização inteira;
+otimização semidefinida;
+técnicas poliédricas;
+algoritmos sobre redes;
+algoritmos de aproximação;
+algoritmos parametrizados.
+
+<p>RESPONSÁVEIS:&nbsp;
+Carlos Eduardo Ferreira
+Marcel Kenji de Carli Silva
+Yoshiko Wakabayashi
+
+<p>PRÉ-REQUISITOS:&nbsp;
+<a href="MAC0452.html">MAC0452</a>.
+
+<p>CARGA HORÁRIA SEMANAL E NÚMERO DE CRÉDITOS:&nbsp;
+3 horas, 4 créditos-aula e 0 créditos-trabalho.
+
+<p>CRITÉRIO DE AVALIAÇÃO DA APRENDIZAGEM:&nbsp; 
+A avaliação é dada por provas, listas de exercícios e eventuais exercícios-programa. O critério é calculado com base na média ponderada das notas de provas e exercícios. Não há norma de recuperação para a matéria. A avaliação será baseada em um volume substancial de exercícios ao longo do semestre, que terão o papel de levar ao amadurecimento do aluno na área da disciplina. Não é possível reproduzir algo parecido no processo de recuperação, que tem de ter lugar em um período muito curto.
+
+<p>BIBLIOGRAFIA BÁSICA:&nbsp;
+<ul>
+
+<li>
+	Artigos recentes em revistas especializadas.
+</li>
+
+<li
+</ul> 
+
+<p>BIBLIOGRAFIA COMPLEMENTAR:
+<ul>
+	<li>
+		A. Schrijver,
+		<i>Combinatorial Optimization: Polyhedra and Efficiency</i>,
+		Springer Verlag, 2003.
+	</li>
+
+	<li>
+		W.J. Cook, W.H. Cunningham, W.R. Pulleyblank, A. Schrijver,
+		<i>Combinatorial Optimization</i>,
+		Wiley, 1998.
+	</li>
+
+	<li>
+		D.P. Williamson, D.B. Schmoys,
+		<i>Approximation Algorithms</i>,
+		Cambridge, 2011.
+	</li>
+
+	<li>
+		B. Gärtner, J. Matousek,
+		<i>Approximation Algorithms and Semidefinite Programming</i>,
+		Springer, 2012.
+	</li>
+
+	<li>
+		M. Cygan, F.V. Fomin, Ł. Kowalik, D. Lokshtanov, D. Marx, M. Pilipczuk, S. Saurabh,
+		<i>Parameterized Algorithms</i>,
+		Springer, 2015.
+	</li>
+</ul>
+
+
+</blockquote>
+
+
+<p>&nbsp;
+<p>[Veja dados da disciplina 
+<a href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0552"
+>no JúpiterWeb</a>]

--- a/miscelanea/premioPIPA.html
+++ b/miscelanea/premioPIPA.html
@@ -2,7 +2,7 @@
 title: 'PIPA: Prêmio de incentivo à Participação em Atividades'
 layout: text
 author: apoio@bcc
-date: 2020-11-12
+date: 2022-07-26
 ---
 <section>
     <center>
@@ -37,16 +37,16 @@ date: 2020-11-12
         no canal do BCC no YouTube.
     </p>
 
-    <p> Para o primeiro semestre de 2022 estamos oferecendo prêmios em duas categorias: Individual e Grupo.</p>
-    <p>Na categoria Individual as bolsas tem valor de R$ 750,00 por 6 (seis) meses. Uma bolsa é patrocinada
+    <p> Para o segundo semestre de 2022 estamos oferecendo prêmios em duas categorias: Individual e Grupo.</p>
+    <p>Na categoria Individual as bolsas tem valor de R$ 1000,00 por 6 (seis) meses. Uma bolsa é patrocinada
         pelas empresas <a href="http://www.caelum.com.br"> Caelum</a> e <a href="http://www.alura.com.br"> Alura</a>,
         fundadas por
         ex-alunos do BCC. Outras bolsas estão em negociação. </p>
 
     <p>
-        As inscrições devem ser feitas até 24 de fevereiro de 2022 preenchendo
+        As inscrições devem ser feitas até 15 de agosto de 2022 preenchendo
         <a href="https://forms.gle/YavjdtG76rTFMfLQ8"> este formulário</a>. O resultado será
-        divulgado até 28 de fevereiro de 2022. O início da bolsa será em 1 de março de 2022.
+        divulgado até 29 de agosto de 2022. O início da bolsa será em 1 de setembro de 2022.
     </p>
 
 
@@ -73,10 +73,10 @@ date: 2020-11-12
     </p>
 
     <p>
-        As inscrições devem ser feitas até 24 de fevereiro de 2022
+        As inscrições devem ser feitas até 15 de agosto de 2022
         preenchendo <a href="https://forms.gle/KoimuRNSQ5epX9r49"> este formulário</a>. O
-        resultado será divulgado até 28 de fevereiro de 2022. O pagamento da parcela será
-        em março de 2021.
+        resultado será divulgado até 29 de agosto de 2022. O pagamento da parcela será em
+        setembro de 2022.
     </p>
 
     <p>Vencedores de edições anteriores também podem se inscrever!</p>
@@ -97,6 +97,16 @@ date: 2020-11-12
 
     <p> O pipa existe desde o segundo semestre de 2017 e teve os seguintes vencedores:
     <p>
+
+    <h4>Primeiro semestre de 2022:</h4>
+    <p>
+      <b>Luís Davi Oliveira de Almeida Campos</b> - Notion do BCC <a 
+        href="https://bcc.ime.usp.br/principal/news/2022/03/02/pipa_resultado_2022_1.html">(veja mais)</a>
+    </p>
+    <p>
+      <b>TECS</b> - LGBTecs <a
+        href="https://bcc.ime.usp.br/principal/news/2022/03/02/pipa_resultado_2022_1.html">(veja mais)</a> 
+    </p>
 
     <h4> Primeiro semestre de 2021:</h4>
     <p><b>Artur Magalhães Rodrigues dos Santos</b> - _push podcast <a

--- a/vida_academica/grade.html
+++ b/vida_academica/grade.html
@@ -1212,7 +1212,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0413.html"
     >MAC0413</a>
    <td >Tópicos Avançados de Programação Orientada a Objetos
-   [<a target="_blank" href="http://www.youtube.com/watch?v=_ht0MaTEPig">video</a>]
+   [<a target="_blank" href="https://www.youtube.com/watch?v=AP097mTZYPs">video</a>]
 <!-- sem.id.7 -->
 <td><small>4+2</small>
 
@@ -1341,7 +1341,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0439.html"
     >MAC0439</a>
 <td >Laboratório de Bancos de Dados
-   [<a target="_blank" href="http://www.youtube.com/watch?v=UlEgNyYurwg">video</a>]
+   [<a target="_blank" href="https://www.youtube.com/watch?v=1j4N0E9ckhk">video</a>]
 <!-- sem.id.8 -->
 <td><small>4+2</small>
 
@@ -1430,7 +1430,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0458.html"
     >MAC0458</a>
 <td >Direito e Software
-[<a target="_blank" href="http://www.youtube.com/watch?v=JezLFYZaVhs">video</a>]
+[<a target="_blank" href="https://www.youtube.com/watch?v=q6eQMkA-N3s">video</a>]
 <!-- <span class="badge">Novo!</span> -->
 <!-- sem.id.? -->
 <td><small>2+0</small>
@@ -1440,7 +1440,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0459.html"
     >MAC0459</a>
 <td >Ciência e Engenharia de Dados
-  [<a target="_blank" href="http://www.youtube.com/watch?v=UlEgNyYurwg">video</a>]
+  [<a target="_blank" href="https://www.youtube.com/watch?v=1j4N0E9ckhk">video</a>]
 
 <!-- sem.id.? -->
 <td><small>4+0</small>
@@ -1563,7 +1563,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0485"
+<td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0485.html"
     >MAC0485</a>
 <td >Implicações Sociais da Computação
 <!-- <span class="badge">Novo!</span> -->
@@ -1572,7 +1572,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0536"
+<td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0536.html"
     >MAC0536</a>
 <td >Tópicos de Matemática Discreta II
 <!-- <span class="badge">Novo!</span> -->
@@ -1581,7 +1581,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0546"
+<td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0546.html"
     >MAC0546</a>
 <td >Fundamentos da Internet das Coisas
 <!-- <span class="badge">Novo!</span> -->
@@ -1590,7 +1590,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0552"
+<td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0552.html"
     >MAC0552</a>
 <td >Tópicos de Otimização Combinatória II
 <!-- <span class="badge">Novo!</span> -->
@@ -1635,8 +1635,8 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0755"
-    >MAC0755</a>
+<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0775"
+    >MAC0775</a>
 <td >Métodos Probabilísticos em Combinatória e em Teoria da Computação I 
 <!-- <span class="badge">Novo!</span> -->
 <!-- sem.id.? -->
@@ -1745,7 +1745,7 @@ href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAE0326"
 <td><a
 href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAE0328"
     >MAE0328</a>
-<td >Análise de Regressão
+<td >Modelos de Regressão I
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1753,7 +1753,7 @@ href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAE0328"
 <td><a
 href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAE0330"
     >MAE0330</a>
-<td >Análise Multivariada e Dados
+<td >Análise Multivariada de Dados
 <!-- sem.id.5 -->
 <td><small>6+0</small>
 

--- a/vida_academica/grade.html
+++ b/vida_academica/grade.html
@@ -1155,7 +1155,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 
 
 <tr>
-<td><a href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAC0345"
+<td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0345.html"
     >MAC0345</a>
 <td >Desafios de Programação Avançados
 <td><small>4+2</small>

--- a/vida_academica/grade.html
+++ b/vida_academica/grade.html
@@ -54,7 +54,7 @@ essencialmente a de <a href="/curriculo2015/">2015</a>.
 
 <tr>
     <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0105.html" >MAC0105</a></td>
-    <td>Fundamentos de Matemática para a Computação</td>
+    <td>Fundamentos de Matemática para a Computação [<a target="_blank" href="https://www.youtube.com/watch?v=gUniDcS3Czc">video</a>]</td>
     <td><small>4+0</small></td>
 </tr>
 
@@ -98,7 +98,7 @@ essencialmente a de <a href="/curriculo2015/">2015</a>.
 
 <tr>
     <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0121.html">MAC0121</a></td>
-    <td>Algoritmos e Estruturas de Dados I [<a href="http://www.youtube.com/watch?v=0GNTReARNL4">vídeo</a>]</td>
+    <td>Algoritmos e Estruturas de Dados I [<a target="_blank" href="https://www.youtube.com/watch?v=1Q19gS7cGJU">video</a>]</td>
     <!-- <span class="badge">Novo!</span>-->
     <td><small>4+0</small></td>
 </tr>
@@ -106,7 +106,7 @@ essencialmente a de <a href="/curriculo2015/">2015</a>.
 <tr>
     <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0216.html" >MAC0216</a></td>
     <td>Técnicas de Programação I</td>
-    <!--   [<a href="http://www.youtube.com/watch?v=0GNTReARNL4">vídeo</a>] -->
+    <!--   [<a target="_blank" href="http://www.youtube.com/watch?v=0GNTReARNL4">video</a>] -->
     <!-- <span class="badge">Novo!</span> -->
     <td><small>4+2</small></td>
 </tr>
@@ -114,7 +114,7 @@ essencialmente a de <a href="/curriculo2015/">2015</a>.
 <tr>
     <td ><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0239.html" >MAC0239</a></td>
     <td >Introdução à Lógica e Verificação de Programas</td>
-    <!--   [<a href="http://www.youtube.com/watch?v=0GNTReARNL4">vídeo</a>]-->
+    <!--   [<a target="_blank" href="http://www.youtube.com/watch?v=0GNTReARNL4">video</a>]-->
     <!-- <span class="badge">Novo!</span> -->
     <td><small>4+0</small></td>
 </tr>
@@ -172,7 +172,7 @@ essencialmente a de <a href="/curriculo2015/">2015</a>.
 
 <tr>
     <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0323.html">MAC0323</a></td>
-    <td>Algoritmos e Estruturas de Dados II</td>
+    <td>Algoritmos e Estruturas de Dados II [<a target="_blank" href="https://www.youtube.com/watch?v=wBwGn0RfYo8">video</a>]</td>
     <td><small>4+2</small></td>
 </td>
 
@@ -994,7 +994,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0242.html"
     >MAC0242</a>
 <td >Laboratório de Programação II
-  [<a href="http://www.youtube.com/watch?v=rttXbakFsJw">vídeo</a>]
+  [<a target="_blank" href="http://www.youtube.com/watch?v=rttXbakFsJw">video</a>]
 <td><small>4+2</small>
 
 
@@ -1057,7 +1057,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0325.html"
     >MAC0325</a>
 <td >Otimização Combinatória
- [<a href="http://www.youtube.com/watch?v=w873AhZa7UM">vídeo</a>]
+ [<a target="_blank" href="http://www.youtube.com/watch?v=w873AhZa7UM">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1089,7 +1089,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0331.html"
     >MAC0331</a>
 <td >Geometria Computacional
- [<a href="http://www.youtube.com/watch?v=AVRCsodF-Ek">vídeo</a>]
+ [<a target="_blank" href="http://www.youtube.com/watch?v=AVRCsodF-Ek">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1098,7 +1098,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0332.html"
     >MAC0332</a>
 <td >Engenharia de Software
-   [<a href="http://www.youtube.com/watch?v=fITjBNfNOts">vídeo</a>]
+   [<a href="http://www.youtube.com/watch?v=fITjBNfNOts">video</a>]
 <td><small>4+2</small>
 
 
@@ -1212,7 +1212,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0413.html"
     >MAC0413</a>
    <td >Tópicos Avançados de Programação Orientada a Objetos
-   [<a href="http://www.youtube.com/watch?v=_ht0MaTEPig">vídeo</a>]
+   [<a target="_blank" href="http://www.youtube.com/watch?v=_ht0MaTEPig">video</a>]
 <!-- sem.id.7 -->
 <td><small>4+2</small>
 
@@ -1237,7 +1237,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0417.html"
     >MAC0417</a>
 <td >Visão e Processamento de Imagens
-[<a href="http://www.youtube.com/watch?v=jWWg4qx0JOU">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=jWWg4qx0JOU">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1253,7 +1253,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0420.html"
     >MAC0420</a>
 <td >Introdução à Computação Gráfica
-[<a href="http://www.youtube.com/watch?v=jWWg4qx0JOU">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=jWWg4qx0JOU">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1261,7 +1261,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0424.html"
     >MAC0424</a>
 <td >O Computador na Sociedade e na Empresa
-[<a href="http://www.youtube.com/watch?v=kxxJHxna2JY">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=kxxJHxna2JY">video</a>]
 <!-- sem.id.8 -->
 <td><small>4+0</small>
 
@@ -1276,7 +1276,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0426.html"
     >MAC0426</a>
 <td >Sistemas de Bancos de Dados
-   [<a href="http://www.youtube.com/watch?v=fJ8NZYOPLx4">vídeo</a>]
+   [<a target="_blank" href="http://www.youtube.com/watch?v=fJ8NZYOPLx4">video</a>]
 <td><small>4+0</small>
 <tr>
 
@@ -1297,7 +1297,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0431.html"
     >MAC0431</a>
 <td >Introdução à Computação Paralela e Distribuída
-[<a href="http://www.youtube.com/watch?v=FO0DV_cEYXs">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=FO0DV_cEYXs">video</a>]
 <!-- sem.id.5 -->
 <td><small>4+0</small>
 
@@ -1333,7 +1333,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0438.html"
     >MAC0438</a>
 <td >Programação Concorrente
- [<a href="http://www.youtube.com/watch?v=6MBU5gdKbyA">vídeo</a>]
+ [<a target="_blank" href="http://www.youtube.com/watch?v=6MBU5gdKbyA">video</a>]
 
 <td><small>4+0</small>
 
@@ -1341,7 +1341,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0439.html"
     >MAC0439</a>
 <td >Laboratório de Bancos de Dados
-   [<a href="http://www.youtube.com/watch?v=UlEgNyYurwg">vídeo</a>]
+   [<a target="_blank" href="http://www.youtube.com/watch?v=UlEgNyYurwg">video</a>]
 <!-- sem.id.8 -->
 <td><small>4+2</small>
 
@@ -1349,7 +1349,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0441.html"
     >MAC0441</a>
 <td >Programação Orientada a Objetos
- [<a href="http://www.youtube.com/watch?v=1w6_eO7YKzs">vídeo</a>]
+ [<a target="_blank" href="http://www.youtube.com/watch?v=1w6_eO7YKzs">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1364,7 +1364,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0446.html"
     >MAC0446</a>
 <td >Princípios de Interação Humano-Computador
-[<a href="http://www.youtube.com/watch?v=eAnhfERi0jw">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=eAnhfERi0jw">video</a>]
 <!-- sem.id.7 -->
 <td><small>4+0</small>
 
@@ -1379,7 +1379,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0448.html"
     >MAC0448</a>
 <td >Programação para Redes de Computadores
-[<a href="http://www.youtube.com/watch?v=TnWzlxXomb8">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=TnWzlxXomb8">video</a>]
 <!-- sem.id.6 -->
 <td><small>4+0</small>
 
@@ -1387,7 +1387,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0450.html"
     >MAC0450</a>
 <td >Algoritmos de Aproximação
-   [<a href="http://www.youtube.com/watch?v=sBbCyvCfzag">vídeo</a>]
+   [<a target="_blank" href="http://www.youtube.com/watch?v=sBbCyvCfzag">video</a>]
 <td><small>4+0</small>
 
 
@@ -1430,7 +1430,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0458.html"
     >MAC0458</a>
 <td >Direito e Software
-[<a href="http://www.youtube.com/watch?v=JezLFYZaVhs">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=JezLFYZaVhs">video</a>]
 <!-- <span class="badge">Novo!</span> -->
 <!-- sem.id.? -->
 <td><small>2+0</small>
@@ -1440,7 +1440,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=0440620"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0459.html"
     >MAC0459</a>
 <td >Ciência e Engenharia de Dados
-  [<a href="http://www.youtube.com/watch?v=UlEgNyYurwg">vídeo</a>]
+  [<a target="_blank" href="http://www.youtube.com/watch?v=UlEgNyYurwg">video</a>]
 
 <!-- sem.id.? -->
 <td><small>4+0</small>
@@ -2299,7 +2299,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=QBQ2509"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0342.html"
     >MAC0342</a>
 <td >Laboratório de Programação eXtrema
- [<a href="http://www.youtube.com/watch?v=XeQJsKwmNmM">vídeo</a>]
+ [<a target="_blank" href="http://www.youtube.com/watch?v=XeQJsKwmNmM">video</a>]
  <font color="red"></b>(necessário requerimento desde 01/01/2021)<!--(desativada: 31/12/2011)--></b></font>
 <!-- sem.id.7 -->
 <td><small>4+2</small>
@@ -2448,7 +2448,7 @@ href="https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=QBQ2453"
 <td><a href="{{ site.baseurl }}/catalogo2017/disciplinas/MAC0415.html"
     >MAC0415</a>
 <td >Projeto de Compiladores
-[<a href="http://www.youtube.com/watch?v=rVAJu3e5rlw">vídeo</a>]
+[<a target="_blank" href="http://www.youtube.com/watch?v=rVAJu3e5rlw">video</a>]
   <font color="red"></b>(desativada: 02/08/2011)</b></font>
 
 <!-- sem.id.8 -->
@@ -2615,7 +2615,7 @@ href="http://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=MAP0421"
 <div class="divider"></div><br>
 
 <p>
-Veja o <a href="http://uspdigital.usp.br/jupiterweb/jupGradeCurricular?codcg=45">currículo do BCC no JúpiterWeb</a>.
+Veja o <a href="https://uspdigital.usp.br/jupiterweb/listarGradeCurricular?codcg=45&codcur=45052&codhab=1&tipo=N">currículo do BCC no JúpiterWeb</a>.
 </p>
 <br><div  class="divider"></div><br>
 <h2 id="curriculos">Currículos antigos</h2>


### PR DESCRIPTION
Este _pull-request_ tem como objetivo adicionar as informações da segunda edição do prêmio PIPA no site do BCC.