### PR TITLE
Prêmio PIPA 2022/2

### DIFF
--- a/_posts/2022-07-26-pipa_inscricao_2022_2.html
+++ b/_posts/2022-07-26-pipa_inscricao_2022_2.html
@@ -1,0 +1,121 @@
+---
+layout: text
+title: "Inscrições prêmio PIPA 2022/2"
+date: 2022-07-26 00:00
+excerpt: "Estão abertas as inscrições para o prêmio PIPA nas categorias individual
+e em grupo!"
+categories: news
+author: apoio@bcc
+---
+<h4>PIPA: Prêmio de incentivo à participação em atividades </h4>
+
+<p>No Bacharelado em Ciência da Computação temos vários alunos e alunas que desenvolvem, além das atividades didáticas,
+    várias iniciativas extra­curriculares de destaque.</p>
+<p>Alguns exemplos são o <a href="https://uspgamedev.org/" target="_blank">USPGameDev</a> (grupo de desenvolvedores de
+    jogos), <a href="http://hardwarelivreusp.org" target="_blank">HardwareLivre</a> (grupo interessado em plataformas
+    livres de
+    hardware), <a href="https://www.ime.usp.br/~maratona/" target="_blank">MaratonUSP</a> (grupo de alunos interessados
+    em competições de programação), etc.</p>
+<p>Nosso objetivo com este prêmio é valorizar os excelentes alunos e alunas, que tenham um desempenho destacado no curso
+    e, além disso,
+    se envolvam com outras atividades extracurriculares e de formação e desempenhem um papel de liderança contribuindo
+    para o ambiente acadêmico universitário.</p>
+<p>Além disso, esse prêmio também tem o objetivo de incentivar a continuidade das atividades. Desta forma, quem tiver
+    interesse
+    deve submeter um plano de ações para o período do prêmio.</p>
+<p>Esperamos que esse incentivo ajude na formação de lideranças no curso. </p>
+
+<p>Para conhecer algumas das ganhadoras e alguns dos ganhadores das edições
+    passadas do PIPA, assista às entrevistas disponibilizadas
+    <a href="https://www.youtube.com/playlist?list=PLlHCTaNDVU3We8KhVh1BFDkIbyB3tmKB_" target="_blank">aqui</a>
+    no canal do BCC no YouTube.
+</p>
+
+<p>
+    Para o segundo semestre de 2022 estamos oferecendo prêmios em duas
+    categorias: Individual e Grupo.
+</p>
+
+
+<p>
+    Na categoria Individual as bolsas tem o valor de R$ 1000,00 por 6
+    (seis) meses. Uma bolsa é patrocinada pelas empresas
+    <a href="http://www.caelum.com.br"> Caelum</a> e <a href="http://www.alura.com.br"> Alura</a>,
+    fundadas por ex-alunos do BCC. Outras bolsas estão em negociação.
+</p>
+
+
+<p>
+    As inscrições devem ser feitas até 15 de agosto de 2022 preenchendo
+    <a href="https://forms.gle/YavjdtG76rTFMfLQ8"> este formulário</a>. O resultado será
+    divulgado até 29 de agosto de 2022. O início da bolsa será em 1 de setembro de 2022.
+</p>
+
+<p>Vencedores de edições anteriores também podem se inscrever!</p>
+
+<p>
+    O julgamento levará em conta:
+<ul>
+    <li> Histórico escolar do candidato </li>
+    <li> Atividades extra­curriculares desenvolvidas </li>
+    <li> Liderança e envolvimento do aluno com as atividades do BCC </li>
+    <li> Descrição das atividades planejadas para o período do prêmio </li>
+</ul>
+</p>
+
+<p>
+    Na categoria Grupo os prêmios correspondem a 1
+    parcela única no valor de R$ 2.000,00 que venha a auxiliar em alguma atividade de um grupo de
+    alunos(as), já existente ou não, em pesquisa ou extensão. Uma parcela
+    é patrocinada por ex-alunos do BCC. Outras parcelas estão em
+    negociação.
+</p>
+
+<p>
+    As inscrições devem ser feitas até 15 de agosto de 2022
+    preenchendo <a href="https://forms.gle/KoimuRNSQ5epX9r49"> este formulário</a>. O
+    resultado será divulgado até 29 de agosto de 2022. O pagamento da parcela será
+    em setembro de 2022.
+</p>
+
+<p>Vencedores de edições anteriores também podem se inscrever!</p>
+
+<p>
+    O julgamento levará em conta:
+<ul>
+    <li> Histórico escolar dos integrantes do grupo </li>
+    <li> Atividades extra­curriculares desenvolvidas </li>
+    <li> Liderança e envolvimento dos integrantes com as atividades do BCC </li>
+    <li> Descrição das atividades planejadas para o período do prêmio,
+        destacando como o prêmio será aplicado </li>
+</ul>
+</p>
+
+<p>
+    A comissão que selecionará os premiados(as) é composta por professores
+    e alunos do Departamento de Ciência da Computação e por ex-alunos do
+    Bacharelado em Ciência da Computação.
+</p>
+
+<hr>
+<div class="row">
+    <div class="col m6 s12">
+        <center><img src="{{ site.baseurl }}/assets/logobcc.png" height=50></center>
+    </div>
+    <div class="col m6 s12">
+        <center><img src="{{ site.baseurl }}/assets/logoime.png" height=50></center>
+    </div>
+</div>
+<div class="row">
+    <div class="col m6 s12">
+        <a href="https://www.alura.com.br">
+            <center><img src="{{ site.baseurl }}/assets/logoalura.svg" height=50></center>
+        </a>
+    </div>
+    <div class="col m6 s12">
+        <a href="https://www.caelum.com.br">
+            <center><img src="{{ site.baseurl }}/assets/logocaelum.svg" height=50></center>
+        </a>
+    </div>
+</div>
+Imagem obtida com licença creative commons de https://pixabay.com/en/fly-a-kite-child-playing-street-play-1242614/

--- a/miscelanea/premioPIPA.html
+++ b/miscelanea/premioPIPA.html
@@ -2,7 +2,7 @@
 title: 'PIPA: Prêmio de incentivo à Participação em Atividades'
 layout: text
 author: apoio@bcc
-date: 2020-11-12
+date: 2022-07-26
 ---
 <section>
     <center>
@@ -37,16 +37,16 @@ date: 2020-11-12
         no canal do BCC no YouTube.
     </p>
 
-    <p> Para o primeiro semestre de 2022 estamos oferecendo prêmios em duas categorias: Individual e Grupo.</p>
-    <p>Na categoria Individual as bolsas tem valor de R$ 750,00 por 6 (seis) meses. Uma bolsa é patrocinada
+    <p> Para o segundo semestre de 2022 estamos oferecendo prêmios em duas categorias: Individual e Grupo.</p>
+    <p>Na categoria Individual as bolsas tem valor de R$ 1000,00 por 6 (seis) meses. Uma bolsa é patrocinada
         pelas empresas <a href="http://www.caelum.com.br"> Caelum</a> e <a href="http://www.alura.com.br"> Alura</a>,
         fundadas por
         ex-alunos do BCC. Outras bolsas estão em negociação. </p>
 
     <p>
-        As inscrições devem ser feitas até 24 de fevereiro de 2022 preenchendo
+        As inscrições devem ser feitas até 15 de agosto de 2022 preenchendo
         <a href="https://forms.gle/YavjdtG76rTFMfLQ8"> este formulário</a>. O resultado será
-        divulgado até 28 de fevereiro de 2022. O início da bolsa será em 1 de março de 2022.
+        divulgado até 29 de agosto de 2022. O início da bolsa será em 1 de setembro de 2022.
     </p>
 
 
@@ -73,10 +73,10 @@ date: 2020-11-12
     </p>
 
     <p>
-        As inscrições devem ser feitas até 24 de fevereiro de 2022
+        As inscrições devem ser feitas até 15 de agosto de 2022
         preenchendo <a href="https://forms.gle/KoimuRNSQ5epX9r49"> este formulário</a>. O
-        resultado será divulgado até 28 de fevereiro de 2022. O pagamento da parcela será
-        em março de 2021.
+        resultado será divulgado até 29 de agosto de 2022. O pagamento da parcela será em
+        setembro de 2022.
     </p>
 
     <p>Vencedores de edições anteriores também podem se inscrever!</p>
@@ -97,6 +97,16 @@ date: 2020-11-12
 
     <p> O pipa existe desde o segundo semestre de 2017 e teve os seguintes vencedores:
     <p>
+
+    <h4>Primeiro semestre de 2022:</h4>
+    <p>
+      <b>Luís Davi Oliveira de Almeida Campos</b> - Notion do BCC <a 
+        href="https://bcc.ime.usp.br/principal/news/2022/03/02/pipa_resultado_2022_1.html">(veja mais)</a>
+    </p>
+    <p>
+      <b>TECS</b> - LGBTecs <a
+        href="https://bcc.ime.usp.br/principal/news/2022/03/02/pipa_resultado_2022_1.html">(veja mais)</a> 
+    </p>
 
     <h4> Primeiro semestre de 2021:</h4>
     <p><b>Artur Magalhães Rodrigues dos Santos</b> - _push podcast <a


### PR DESCRIPTION
Este _pull-request_ tem como objetivo divulgar a abertura das inscrições da segunda edição do prêmio PIPA de 2022.