### PR TITLE
Inclusão do CompReqs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,6 +41,7 @@
       <li><a class="white-text" href="{{ site.baseurl }}/miscelanea/gruposExtensao.html">Grupos de Extensão</a></li>
       <li><a class="white-text" href="https://akafts.github.io/yggdrasil2/" target="_blank">yggdrasil2</a></li>
       <li><a class="white-text" href="https://bcc-ime.notion.site/" target="_blank">Notion do BCC</a></li>
+      <li><a class="white-text" href="http://bcc.ime.usp.br/compreqs/" target="_blank">CompReqs</a></li>
       <li><a class="white-text" href="http://bcc.ime.usp.br/matrusp/" target="_blank">MatrUSP</a></li>
       <li><a class="white-text" href="https://www.youtube.com/channel/UCwyRmPEEQuyhc9dFzDpLpdA"
           target="_blank">YouTube</a></li>

--- a/_posts/2022-08-01-compreqs_no_site_do_bcc.html
+++ b/_posts/2022-08-01-compreqs_no_site_do_bcc.html
@@ -1,0 +1,29 @@
+---
+layout: text
+title: "Compreqs no site do BCC"
+date: 2022-08-01 00:00
+excerpt: "Agora você pode visualizar os requisitos da disciplina que quer cursar de forma interativa no site do BCC!"
+categories: news
+author: apoio@bcc
+---
+
+<p>
+	O CompReqs é uma aplicação desenvolvida pelo grupo de extensão CodeLab na iniciativa dev.boost() de 2020. Seu objetivo é mostrar, de forma interativa e em uma estrutura de grafos, os
+	requisitos das disciplinas do BCC.
+</p>
+
+<p>
+	O sistema permite ao usuário pesquisar a disciplina desejada e visualizar, com um certo nível de profundidade do grafo, os requisitos dessa disciplina. Na pesquisa, são aceitos tanto 
+	o código quanto o nome da disciplina.
+</p>
+
+<p>
+	O código-fonte da aplicação é aberto e disponível no <a href="https://gitlab.com/uspcodelab/devboost-2020-1">GitLab</a>. Você pode acessá-la por meio da seção "CompReqs" no menu do
+	site ou clicando no botão abaixo!
+</p>
+
+<center>
+	<h5>
+		<a href="https://bcc.ime.usp.br/compreqs/" target="_blank">Acesse o CompReqs!</a>
+	</h5>
+</center>


### PR DESCRIPTION
Este _pull-request_ tem como objetivo adicionar uma entrada para o CompReqs (https://gitlab.com/uspcodelab/devboost-2020-1/) no menu do site do BCC.